### PR TITLE
Add pry and pry-byebug for easier development

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,11 +10,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    byebug (11.1.3)
+    coderay (1.1.3)
     diff-lcs (1.3)
     hashie (3.6.0)
     jaro_winkler (1.5.4)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
+    method_source (1.0.0)
     mini_portile2 (2.4.0)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
@@ -24,6 +27,12 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -67,6 +76,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   omniauth-realme!
+  pry-byebug
   rack-test
   rake (~> 12.0)
   rspec (~> 3.0)

--- a/omniauth-realme.gemspec
+++ b/omniauth-realme.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'uuid', '~> 2.0'
 
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
pry and pry-byebug (which integrates the byebug debugger with pry) are extremely convenient development dependencies.

_I_ always reach for pry when I'm working on a project but, given that it's not really _required_ for dev, I get that you might not want to add it as a dev dependency so no worries if you feel you need to reject this :shrug: