### PR TITLE
Allow users to opt-in to SAML validation errors from ruby-saml

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ OmniAuth::Strategies::Realme.configure do |config|
   # validation errors. We recommend enabling this in Rails development env at
   # least.
   #
-  raise_exceptions_for_saml_validation_errors = true if Rails.env.development? # default: false
+  config.raise_exceptions_for_saml_validation_errors = Rails.env.development? # default: false
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ OmniAuth::Strategies::Realme.configure do |config|
   # See: https://github.com/onelogin/ruby-saml#clock-drift
   #
   config.allowed_clock_drift = 5.seconds # default is 0.seconds
+
+  # It can be very useful to fail noisily in development if there are SAML
+  # validation errors. We recommend enabling this in Rails development env at
+  # least.
+  #
+  raise_exceptions_for_saml_validation_errors = true if Rails.env.development? # default: false
 end
 ```
 

--- a/lib/omniauth/strategies/realme.rb
+++ b/lib/omniauth/strategies/realme.rb
@@ -55,7 +55,7 @@ module OmniAuth
         settings.authn_context                      = options.fetch('auth_strength', 'urn:nzl:govt:ict:stds:authn:deployment:GLS:SAML:2.0:ac:classes:LowStrength')
         settings.protocol_binding                   = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
         settings.assertion_consumer_service_binding = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
-        settings.soft = true
+        settings.soft                               = !options.fetch('raise_exceptions_for_saml_validation_errors', false)
 
         settings.security[:authn_requests_signed] = true
 


### PR DESCRIPTION
Getting exceptions from SAML validation errors can be really useful for
debugging, especially near the start of a project or when working with a
new IdP implementation. This opt-in setting allows users to choose to
see them.

The example in the docs recommends turning them on for Rails development
env only.

This change is backwards compatible. If the option is not specified it
defaults to off (which is the behaviour before this change)