### PR TITLE
Implement standard OmniAuth error handling as an opt-in behaviour

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: false
 
+Metrics/ClassLength:
+  Max: 120
+
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*" # specs can have long blocks

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Realme provides the necessary `service-metadata.xml` files for their side of the
 OmniAuth.config.on_failure = Proc.new { |env| OmniAuthCallbacksController.action(:failure).call(env) }
 
 OmniAuth.configure do |config|
-  # Always wedirect to the failure endpoint if there is an error. Normally the
+  # Always redirect to the failure endpoint if there is an error. Normally the
   # exception would just be raised in development mode. This is useful for
   # testing your Realme error handling in development.
   config.failure_raise_out_environments = []

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ module Users
     skip_before_action :verify_authenticity_token
 
     def realme
-      @user = User.from_omniauth('realme', session.delete(:uid))
+      realme_flt_token = request.env["omniauth.auth"]["uid"]
+      @user = User.from_omniauth('realme', realme_flt_token)
 
       unless @user.valid?
         @user.errors.each { |err| @user.errors.delete(err) }


### PR DESCRIPTION
When the appropriate option is set in the config, the strategy will now
use OmniAuth error reporting behaviour i.e. it will redirect to the
OmniAuth error Rack app.

This behaviour is currently opt-in to not break existing installations.

closes #20 