### PR TITLE
Sometimes ruby-saml responses have no status message

### DIFF
--- a/lib/omniauth/strategies/realme.rb
+++ b/lib/omniauth/strategies/realme.rb
@@ -108,7 +108,8 @@ module OmniAuth
           if response.is_valid? # rubocop:disable Style/IfInsideElse
             @uid = response.nameid
           else
-            ex = create_exception_for(status_code: response.status_code, message: response.status_message.strip)
+            msg = response.status_message ? response.status_message.strip : ''
+            ex = create_exception_for(status_code: response.status_code, message: msg)
 
             # fail!() returns a rack response which this callback must also
             # return if OmniAuth error handling is to work correctly.


### PR DESCRIPTION
It seems like `OneLogin::RubySaml::Response#status_message` occasionally returns `nil` e.g. we are seeing some of these in our exception monitoring:

![image](https://user-images.githubusercontent.com/599867/100017706-33fdfc80-2e40-11eb-9236-bfa688efe71e.png)


We are using `status_message` to build an error message but we want to just continue if it is missing.