### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.4.9
           - 2.5.8
           - 2.6.6
           - 2.7.1
+          - 3.0.0
 
     name: Ruby ${{ matrix.ruby }} sample
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-realme (0.2.0)
+    omniauth-realme (0.2.1)
       omniauth (~> 1.0)
       ruby-saml (~> 1.5)
       uuid (~> 2.0)
@@ -18,9 +18,10 @@ GEM
     macaddr (1.7.2)
       systemu (~> 2.6.5)
     method_source (1.0.0)
-    mini_portile2 (2.4.0)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    mini_portile2 (2.5.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
@@ -33,6 +34,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)

--- a/lib/omniauth/realme/version.rb
+++ b/lib/omniauth/realme/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Realme
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
Just a little version bump to include https://github.com/DigitalNZ/omniauth-realme/commit/8e6c39aef02867df2ca4795ad586deab6705432a - I'm hoping we can do a release to rubygems after this lands?

I had to update the Github Actions CI matrix to make this pass (I removed 2.4.9 (which no longer supports latest nokogiri) and added 3.0.0)