### PR TITLE
fix: relax dependency constraints to allow minor versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,10 @@ PATH
   remote: .
   specs:
     omniauth-realme (2.1.1)
-      omniauth (~> 2.0.4)
-      omniauth-rails_csrf_protection (~> 1.0.0)
-      ruby-saml (~> 1.13.0)
-      uuid (~> 2.3.9)
+      omniauth (~> 2.0)
+      omniauth-rails_csrf_protection (~> 1.0)
+      ruby-saml (~> 1.13)
+      uuid (~> 2.3)
 
 GEM
   remote: https://rubygems.org/

--- a/omniauth-realme.gemspec
+++ b/omniauth-realme.gemspec
@@ -28,10 +28,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'omniauth', '~> 2.0.4'
-  spec.add_dependency 'omniauth-rails_csrf_protection', '~> 1.0.0'
-  spec.add_dependency 'ruby-saml', '~> 1.13.0'
-  spec.add_dependency 'uuid', '~> 2.3.9'
+  spec.add_dependency 'omniauth', '~> 2.0'
+  spec.add_dependency 'omniauth-rails_csrf_protection', '~> 1.0'
+  spec.add_dependency 'ruby-saml', '~> 1.13'
+  spec.add_dependency 'uuid', '~> 2.3'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
The current constraints lock to patch versions only meaning further non-breaking changes and fixes cannot be pulled in - for example, GHSA-jw9c-mfg7-9rx2 has been patched in v1.17.0 but currently we're locked to v1.13.x