### PR TITLE
ci: don't fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   ci_checks:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - 2.5.8


### PR DESCRIPTION
By default matrixes [fail fast](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#handling-failures) which makes it harder to know what _all_ your problems are i.e. if a change is failing for just one version of Ruby but not others 