### PR TITLE
ci: run on `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   ci_checks:


### PR DESCRIPTION
`master` has since been renamed to `main`, but this wasn't updated so CI no longer runs when changes are merged in